### PR TITLE
Add question label and force response output in getSurveyQuestions()

### DIFF
--- a/R/getSurveyQuestions.R
+++ b/R/getSurveyQuestions.R
@@ -52,11 +52,13 @@ getSurveyQuestions <- function(surveyID) {
   resp <- qualtricsApiRequest("GET", root_url)
   # Get question information and map
   qi <- resp$result$questions
-  # Add questions
+  # Add questions, question labels and force response info
+  qlabel <- unlist(sapply(qi, function(x) as.character(x$questionLabel))) #question label
+  
   quest <- data.frame(
     "qid" = names(qi),
     "question" = sapply(qi, function(x) x$questionText),
-    "qlabel" = sapply(qi, function(x) x$questionLabel),
+    "qlabel" <- ifelse(length(qlabel) == 0, NA, sapply(qi, function(x) as.character(x$questionLabel))), #Replace NULL NA for no question labels
     "force_resp" = sapply(qi, function(x) x$validation$doesForceResponses),
     stringsAsFactors = FALSE
   )

--- a/R/getSurveyQuestions.R
+++ b/R/getSurveyQuestions.R
@@ -57,7 +57,7 @@ getSurveyQuestions <- function(surveyID) {
     "qid" = names(qi),
     "question" = sapply(qi, function(x) x$questionText),
     "qlabel" = sapply(qi, function(x) x$questionLabel),
-    "force_resp" = sapply(qi, function(x) x$validation$doesForceResponses)
+    "force_resp" = sapply(qi, function(x) x$validation$doesForceResponses),
     stringsAsFactors = FALSE
   )
   # Row names

--- a/R/getSurveyQuestions.R
+++ b/R/getSurveyQuestions.R
@@ -52,10 +52,12 @@ getSurveyQuestions <- function(surveyID) {
   resp <- qualtricsApiRequest("GET", root_url)
   # Get question information and map
   qi <- resp$result$questions
-  # Add questions
+  # Add questionss
   quest <- data.frame(
     "qid" = names(qi),
     "question" = sapply(qi, function(x) x$questionText),
+    "qlabel" = sapply(qi, function(x) x$questionLabel),
+    "force_resp" = sapply(qi, function(x) x$validation$doesForceResponses)
     stringsAsFactors = FALSE
   )
   # Row names

--- a/R/getSurveyQuestions.R
+++ b/R/getSurveyQuestions.R
@@ -19,7 +19,7 @@
 #' @param surveyID String. Unique ID for the survey you want to download. Returned as 'id' by the \link[qualtRics]{getSurveys} function.
 #'
 #' @seealso See \url{https://api.qualtrics.com/docs} for documentation on the Qualtrics API.
-#' @author Jasper Ginn
+#' @author Jasper Ginn, Phoebe Wong
 #' @importFrom httr GET
 #' @importFrom httr content
 #' @importFrom httr add_headers

--- a/R/getSurveyQuestions.R
+++ b/R/getSurveyQuestions.R
@@ -52,7 +52,7 @@ getSurveyQuestions <- function(surveyID) {
   resp <- qualtricsApiRequest("GET", root_url)
   # Get question information and map
   qi <- resp$result$questions
-  # Add questionss
+  # Add questions
   quest <- data.frame(
     "qid" = names(qi),
     "question" = sapply(qi, function(x) x$questionText),


### PR DESCRIPTION
I added question label in response to issue #35 in the output of `getSurveyQuestions()`. 

I also added force response (logical) in the output because I personally found it helpful as I sometimes use that to check if all questions have force response validated before publishing the survey. Let me know what do you think. Thanks!