### PR TITLE
readSurvey: Use UTF-8 by default for current format

### DIFF
--- a/R/readSurvey.R
+++ b/R/readSurvey.R
@@ -43,14 +43,14 @@
 readSurvey <- function(file_name,
                        convertStandardColumns = TRUE,
                        stripHTML = TRUE,
-                       fileEncoding = "",
+                       fileEncoding = "UTF-8",
                        legacyFormat = FALSE) {
   # check if file exists
   assert_surveyFile_exists(file_name)
   # skip 2 rows if legacyFormat, else 3 when loading the data
   skipNr <- ifelse(legacyFormat, 2, 3)
   # set fileEncoding to UTF-8-BOM if not set otherwise and legacyFormat is specified
-  fileEncoding <- ifelse(legacyFormat & fileEncoding == "", "UTF-8-BOM", fileEncoding)
+  fileEncoding <- ifelse(legacyFormat & fileEncoding == "UTF-8", "UTF-8-BOM", fileEncoding)
   # import data including variable names (row 1) and variable labels (row 2)
   rawdata <- read.csv(file = file_name,
                       header = FALSE,

--- a/man/readSurvey.Rd
+++ b/man/readSurvey.Rd
@@ -5,7 +5,7 @@
 \title{Read comma separated csv file from Qualtrics.}
 \usage{
 readSurvey(file_name, convertStandardColumns = TRUE, stripHTML = TRUE,
-  fileEncoding = "", legacyFormat = FALSE)
+  fileEncoding = "UTF-8", legacyFormat = FALSE)
 }
 \arguments{
 \item{file_name}{String. A csv data file.}


### PR DESCRIPTION
Qualtrics provides the current csv format with UTF-8 encoding, so better set it by default.