### PR TITLE
Switch to readr::read_csv for importing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Description: Qualtrics <https://www.qualtrics.com/about/>
 Imports:
     httr,
     stringr,
+    readr,
     jsonlite,
     assertthat,
     sjlabelled,

--- a/R/getSurvey.R
+++ b/R/getSurvey.R
@@ -145,7 +145,7 @@ getSurvey <- function(surveyID,
   # Download, unzip and return file path
   survey.fpath <- downloadQualtricsExport(check_url, verbose = verbose)
   # Read data
-  data <- readSurvey(survey.fpath, convertStandardColumns = convertStandardColumns, fileEncoding = fileEncoding)
+  data <- readSurvey(survey.fpath, convertStandardColumns = convertStandardColumns)
   # Save survey as RDS file in temp folder so that it can be easily retrieved this session.
   saveRDS(data, paste0(tempdir(), "/", surveyID, ".rds"))
   # Remove tmpfiles

--- a/R/readSurvey.R
+++ b/R/readSurvey.R
@@ -25,8 +25,7 @@
 #' @param file_name String. A csv data file.
 #' @param convertStandardColumns Logical. If TRUE, then the function will convert general data columns (first name, last name, lat, lon, ip address, startdate, enddate etc.) to their proper format. defaults to TRUE.
 #' @param stripHTML Logical. If TRUE, then remove html tags. Defaults to TRUE
-#' @param fileEncoding Set this argument to import your survey using a specific encoding. (see \code{\link{utils}{read.csv}} and the 'Encoding' section in \code{\link{base}{file}})
-#' @param legacyFormat Logical. If TRUE, then import "legacy" format csv files (as of 2017). This option also sets fileEncoding to UTF-8-BOM if not specified otherwise. Defaults to FALSE
+#' @param legacyFormat Logical. If TRUE, then import "legacy" format csv files (as of 2017). Defaults to FALSE
 #'
 #' @author Adrian Brugger, Stefan Borer & Jasper Ginn
 #' @importFrom utils read.csv
@@ -43,37 +42,24 @@
 readSurvey <- function(file_name,
                        convertStandardColumns = TRUE,
                        stripHTML = TRUE,
-                       fileEncoding = "UTF-8",
                        legacyFormat = FALSE) {
   # check if file exists
   assert_surveyFile_exists(file_name)
   # skip 2 rows if legacyFormat, else 3 when loading the data
   skipNr <- ifelse(legacyFormat, 2, 3)
-  # set fileEncoding to UTF-8-BOM if not set otherwise and legacyFormat is specified
-  fileEncoding <- ifelse(legacyFormat & fileEncoding == "UTF-8", "UTF-8-BOM", fileEncoding)
   # import data including variable names (row 1) and variable labels (row 2)
-  rawdata <- read.csv(file = file_name,
-                      header = FALSE,
-                      sep = ',',
-                      stringsAsFactors = FALSE,
-                      fileEncoding = fileEncoding,
-                      skip = skipNr)
-  header <- read.csv(file = file_name,
-                     header = TRUE,
-                     sep = ',',
-                     stringsAsFactors = FALSE,
-                     fileEncoding = fileEncoding,
-                     nrows = 1)
+  rawdata <- readr::read_csv(file = file_name,
+                             col_names = FALSE,
+                             skip = skipNr)
+  header <- readr::read_csv(file = file_name,
+                            col_names = TRUE,
+                            n_max = 1)
+  # make them data.frame's, else the factor conversion in `inferDataTypes` crashes
+  rawdata <- as.data.frame(rawdata)
+  header <- as.data.frame(header)
   # Add names
   names(rawdata) <- names(header)
-  # Import importids
-  importids <- unname(unlist(read.csv(file = file_name,
-                                      header = F,
-                                      sep = ',',
-                                      stringsAsFactors = FALSE,
-                                      fileEncoding = fileEncoding,
-                                      skip = 2,
-                                      nrows = 1)))
+
   # If Qualtrics adds an empty column at the end, remove it
   if(grepl(",$", readLines(file_name, n = 1))) {
     header <- header[, 1:(ncol(header)-1)]

--- a/R/utils.R
+++ b/R/utils.R
@@ -353,28 +353,30 @@ inferDataTypes <- function(data,
                            verbose = FALSE) {
   # Download survey metadata
   #sm <- getSurveyMetadata(surveyID, root_url = root_url)
+
+  # These are added to qualtrics surveys
+  qNum <- c("LocationLatitude", "LocationLongitude", "Progress",
+            "Duration..in.seconds",
+            # legacy
+            "LocationAccuracy")
+  qChar <- c('IPAddress','ResponseID','RecipientLastName',
+             'RecipientFirstName','RecipientEmail','ExternalDataReference',
+             'ExternalReference', 'DistributionChannel', # Last two are unclear
+             # legacy
+             "V1", "V3", "V4", "V5", "V6")
+  qFact <- c('ResponseSet',
+             # legacy
+             "V2")
+  qBin <- c("Finished", "Status",
+            # legacy
+            "V7", "V10")
+  qDate <- c('StartDate','EndDate', 'RecordedDate',
+             # legacy
+             "V8", "V9")
+
   # For each column, cycle and assign
   for(col.name in names(data)) {
     #print(col.name)
-    # These are added to qualtrics surveys
-    qNum <- c("LocationLatitude", "LocationLongitude", "Progress",
-              "Duration..in.seconds",
-              # legacy
-              "LocationAccuracy")
-    qChar <- c('IPAddress','ResponseID','RecipientLastName',
-               'RecipientFirstName','RecipientEmail','ExternalDataReference',
-               'ExternalReference', 'DistributionChannel', # Last two are unclear
-               # legacy
-                "V1", "V3", "V4", "V5", "V6")
-    qFact <- c('ResponseSet',
-               # legacy
-               "V2")
-    qBin <- c("Finished", "Status",
-              # legacy
-              "V7", "V10")
-    qDate <- c('StartDate','EndDate', 'RecordedDate',
-               # legacy
-               "V8", "V9")
     # Check for generic data
     if(col.name %in% qNum) {
       data[,col.name] <- as.numeric(data[,col.name])
@@ -385,7 +387,7 @@ inferDataTypes <- function(data,
     } else if(col.name %in% qBin) {
       data[,col.name] <- factor(data[,col.name], levels=c("0", "1"))
     } else if(col.name %in% qDate) {
-      data[,col.name] <- lubridate::as_datetime(data[,col.name], tz=NULL)
+      # data[,col.name] <- lubridate::as_datetime(data[,col.name], tz=NULL)
     } else {
       NULL
     }

--- a/man/readSurvey.Rd
+++ b/man/readSurvey.Rd
@@ -5,7 +5,7 @@
 \title{Read comma separated csv file from Qualtrics.}
 \usage{
 readSurvey(file_name, convertStandardColumns = TRUE, stripHTML = TRUE,
-  fileEncoding = "UTF-8", legacyFormat = FALSE)
+  legacyFormat = FALSE)
 }
 \arguments{
 \item{file_name}{String. A csv data file.}
@@ -14,9 +14,7 @@ readSurvey(file_name, convertStandardColumns = TRUE, stripHTML = TRUE,
 
 \item{stripHTML}{Logical. If TRUE, then remove html tags. Defaults to TRUE}
 
-\item{fileEncoding}{Set this argument to import your survey using a specific encoding. (see \code{\link{utils}{read.csv}} and the 'Encoding' section in \code{\link{base}{file}})}
-
-\item{legacyFormat}{Logical. If TRUE, then import "legacy" format csv files (as of 2017). This option also sets fileEncoding to UTF-8-BOM if not specified otherwise. Defaults to FALSE}
+\item{legacyFormat}{Logical. If TRUE, then import "legacy" format csv files (as of 2017). Defaults to FALSE}
 }
 \value{
 A data frame. Variable labels are stored as attributes. They are not printed on


### PR DESCRIPTION
This fixes a number of problems when importing unicode data.
Readr detects the fileEncoding itself, so the parameter is removed.
Also readr guesses the column types pretty accurately, so
inferDataTypes might not be needed anymore in readSurvey.
For now ignore lubridate (doesn't seem to go well otherwise).